### PR TITLE
feat(log): add message field to customize the hardcoded entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/phuslu/log
+module github.com/benbenbang/log
 
-go 1.18
+go 1.25

--- a/logger.go
+++ b/logger.go
@@ -29,9 +29,10 @@ var DefaultLogger = Logger{
 
 // Entry represents a log entry. It is instanced by one of the level method of Logger and finalized by the Msg or Msgf method.
 type Entry struct {
-	buf   []byte
-	Level Level
-	w     Writer
+	buf    []byte
+	Level  Level
+	w      Writer
+	logger *Logger
 }
 
 // Writer defines an entry writer interface.
@@ -100,6 +101,9 @@ type Logger struct {
 
 	// TimeLocation specifics that the location which TimeFormat used. It uses time.Local if empty.
 	TimeLocation *time.Location
+
+	// MessageField defines the time field name in output.  It uses "message" in if empty.
+	MessageField string
 
 	// Context specifies an optional context of logger.
 	Context Context
@@ -465,6 +469,7 @@ func (l *Logger) header(level Level) *Entry {
 	e := epool.Get().(*Entry)
 	e.buf = e.buf[:0]
 	e.Level = level
+	e.logger = l
 	if l.Writer != nil {
 		e.w = l.Writer
 	} else {
@@ -1859,7 +1864,13 @@ func (e *Entry) Msg(msg string) {
 	}
 
 	if msg != "" {
-		e.buf = append(e.buf, ",\"message\":\""...)
+		messageField := "message"
+		if e.logger != nil && e.logger.MessageField != "" {
+			messageField = e.logger.MessageField
+		}
+		e.buf = append(e.buf, ",\""...)
+		e.buf = append(e.buf, messageField...)
+		e.buf = append(e.buf, "\":\""...)
 		e.string(msg)
 		e.buf = append(e.buf, "\"}\n"...)
 	} else {
@@ -1900,7 +1911,13 @@ func (e *Entry) Msgf(format string, v ...any) {
 
 	b := bbpool.Get().(*bb)
 	b.B = b.B[:0]
-	e.buf = append(e.buf, ",\"message\":\""...)
+	messageField := "message"
+	if e.logger != nil && e.logger.MessageField != "" {
+		messageField = e.logger.MessageField
+	}
+	e.buf = append(e.buf, ",\""...)
+	e.buf = append(e.buf, messageField...)
+	e.buf = append(e.buf, "\":\""...)
 	fmt.Fprintf(b, format, v...)
 	e.bytes(b.B)
 	e.buf = append(e.buf, '"')
@@ -1918,7 +1935,13 @@ func (e *Entry) Msgs(args ...any) {
 
 	b := bbpool.Get().(*bb)
 	b.B = b.B[:0]
-	e.buf = append(e.buf, ",\"message\":\""...)
+	messageField := "message"
+	if e.logger != nil && e.logger.MessageField != "" {
+		messageField = e.logger.MessageField
+	}
+	e.buf = append(e.buf, ",\""...)
+	e.buf = append(e.buf, messageField...)
+	e.buf = append(e.buf, "\":\""...)
 	fmt.Fprint(b, args...)
 	e.bytes(b.B)
 	e.buf = append(e.buf, '"')


### PR DESCRIPTION
This pull request introduces a configurable message field name in the logger output and updates the project module and Go version. The most significant change is allowing users to specify the field name for log messages, improving flexibility for integrations and custom formats.

**Logger configuration improvements:**

* Added a new `MessageField` member to the `Logger` struct, allowing customization of the log message field name in the output.
* Updated the `Msg`, `Msgf`, and `Msgs` methods in `Entry` to use the configurable `MessageField` from the associated `Logger`, defaulting to `"message"` if not set. [[1]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eL1862-R1873) [[2]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eL1903-R1920) [[3]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eL1921-R1944)
* Associated each `Entry` with its parent `Logger` to access configuration options like `MessageField`. [[1]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eR35) [[2]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eR472)

**Project maintenance:**

* Changed the module path in `go.mod` from `github.com/phuslu/log` to `github.com/benbenbang/log` and updated the Go version requirement from 1.18 to 1.25.